### PR TITLE
Drop Debian 10 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },


### PR DESCRIPTION
includes #44
As can be seen in #24 : Debian 10 does not have a monit package, Debian 11 does. Therefore we should fix our supported OSes in the metadata