### PR TITLE
Drop support for puppetlabs-firewall <5.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.1 < 9.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppet 8 support according to dependencies of puppetlabs-firewall requires at least version 5.0.0